### PR TITLE
fix(erc20-balances): include recipient address in balance lookups

### DIFF
--- a/erc20-balances/src/lib.rs
+++ b/erc20-balances/src/lib.rs
@@ -10,16 +10,16 @@ fn map_events(params: String, transfers: pb::transfers::v1::Events) -> Result<pb
     let mut events = pb::balances::v1::Events::default();
     let chunk_size = params.parse::<usize>().expect("Failed to parse chunk_size");
 
-    // Collect unique tokens by owners
+    // Collect unique tokens by owners (both sender and recipient)
     let contracts_by_address = transfers
         .transactions
         .iter()
         .flat_map(|tx| tx.logs.iter())
-        .filter_map(|log| {
+        .flat_map(|log| {
             if let Some(pb::transfers::v1::log::Log::Transfer(transfer)) = &log.log {
-                Some((&log.address, &transfer.from))
+                vec![(&log.address, &transfer.from), (&log.address, &transfer.to)]
             } else {
-                None
+                vec![]
             }
         })
         .collect::<HashSet<(&common::Address, &common::Address)>>()


### PR DESCRIPTION
  ## Summary

  - Fixed bug where only the sender (`from`) address was tracked for ERC-20 balance updates
  - Recipient (`to`) balances were missing from the output until they became senders in a subsequent transfer

  ## Problem

  In `erc20-balances/src/lib.rs`, the code was only extracting the `from` address from Transfer events:

  ```rust
  .filter_map(|log| {
      if let Some(pb::transfers::v1::log::Log::Transfer(transfer)) = &log.log {
          Some((&log.address, &transfer.from))  // BUG: Only sender, missing recipient
      } else {
          None
      }
  })

  ``` 
  
  This meant that when a Transfer event occurred (from=Alice, to=Bob), only Alice's balance was looked up and recorded. Bob's balance would only appear when he became a sender in another transfer.
  
  Solution

  Changed filter_map to flat_map to return both addresses:
  ```rust
  .flat_map(|log| {
      if let Some(pb::transfers::v1::log::Log::Transfer(transfer)) = &log.log {
          vec![(&log.address, &transfer.from), (&log.address, &transfer.to)]
      } else {
          vec![]
      }
  })
  ```
  The existing HashSet deduplication ensures no duplicate RPC calls are made if an address appears multiple times in the same block.

  Test plan

  - Built successfully with cargo build --target wasm32-unknown-unknown --release
  - Tested on block 24032847 (Ethereum mainnet) with RLUSD token transfers
  - Verified both sender and recipient balances now appear in output

  Before fix: Only 1 RLUSD balance entry per transfer
  After fix: 2 RLUSD balance entries per transfer (sender + recipient)
