### PR TITLE
Filter out invalid addresses

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -142,3 +142,9 @@ pub fn bigint_to_i32(bigint: &substreams::scalar::BigInt) -> Option<i32> {
     }
     Some(bigint.to_i32())
 }
+
+/// Validates if an address is a valid EVM address.
+/// Returns true if the address is exactly 20 bytes and not the null address.
+pub fn is_valid_evm_address(address: &[u8]) -> bool {
+    address.len() == 20 && address != NULL_ADDRESS
+}

--- a/erc20-balances/src/lib.rs
+++ b/erc20-balances/src/lib.rs
@@ -178,10 +178,12 @@ fn map_balance_changes(transfers: transfers_pb::Events, tokens: tokens_pb::Event
 
     let mut balance_changes = balances_pb::BalanceChanges::default();
     for (contract, address) in contracts_by_address {
-        balance_changes.balance_changes.push(balances_pb::BalanceChange {
-            contract: Some(contract.to_vec()),
-            address: address.to_vec(),
-        });
+        if common::is_valid_evm_address(contract) && common::is_valid_evm_address(address) {
+            balance_changes.balance_changes.push(balances_pb::BalanceChange {
+                contract: Some(contract.to_vec()),
+                address: address.to_vec(),
+            });
+        }
     }
     Ok(balance_changes)
 }

--- a/native-balances/src/lib.rs
+++ b/native-balances/src/lib.rs
@@ -85,7 +85,9 @@ pub fn map_balance_changes(block: Block) -> Result<BalanceChanges, Error> {
 
     let mut balance_changes = BalanceChanges::default();
     for address in accounts {
-        balance_changes.balance_changes.push(BalanceChange { contract: None, address });
+        if common::is_valid_evm_address(&address) {
+            balance_changes.balance_changes.push(BalanceChange { contract: None, address });
+        }
     }
     Ok(balance_changes)
 }


### PR DESCRIPTION
Current version `evm-balances-v0.3.3` gets stuck on tron-evm because it queries `eth_getBalance` for invalid addresses (i.e. `0x`) and RPC node returns error like `rpc error (code -32602): invalid address hash value"`  that substreams classify as deterministic error, so it keeps retrying it indefinitely.
 
This PR filters out such addresses so it doesn't try to query them.