### PR TITLE
[codex] add caller and minute projections to dex swaps

### DIFF
--- a/evm-dex/clickhouse/examples/Swaps.sql
+++ b/evm-dex/clickhouse/examples/Swaps.sql
@@ -99,3 +99,25 @@ WHERE
     minute IN minutes
 ORDER BY minute DESC, timestamp DESC, block_num DESC
 LIMIT 10;
+
+-- grouped swaps by minute and caller --
+SELECT
+    minute,
+    caller,
+    count() AS swaps_count
+FROM swaps
+WHERE caller = '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45'
+GROUP BY minute, caller
+ORDER BY minute DESC
+LIMIT 10;
+
+-- grouped swaps by minute and tx_from --
+SELECT
+    minute,
+    tx_from,
+    count() AS swaps_count
+FROM swaps
+WHERE tx_from = '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45'
+GROUP BY minute, tx_from
+ORDER BY minute DESC
+LIMIT 10;

--- a/evm-dex/clickhouse/schema.2.mv.swaps.sql
+++ b/evm-dex/clickhouse/schema.2.mv.swaps.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS swaps (
     tx_index                    UInt32, -- derived from Substreams
     tx_hash                     String,
     tx_from                     String,
+    caller                      String COMMENT 'Call-level caller address, falling back to tx_from when unavailable',
 
     -- log --
     log_index                   UInt32, -- derived from Substreams
@@ -48,6 +49,7 @@ CREATE TABLE IF NOT EXISTS swaps (
     CONSTRAINT log_topic0_not_empty CHECK log_topic0 != '',
     CONSTRAINT tx_hash_not_empty CHECK tx_hash != '',
     CONSTRAINT tx_from_not_empty CHECK tx_from != '',
+    CONSTRAINT caller_not_empty CHECK caller != '',
     CONSTRAINT factory_not_empty CHECK factory != '',
     CONSTRAINT pool_not_empty CHECK pool != '',
     CONSTRAINT user_not_empty CHECK user != '',
@@ -77,6 +79,7 @@ CREATE TABLE IF NOT EXISTS swaps (
     PROJECTION prj_factory_count ( SELECT factory, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY factory ),
     PROJECTION prj_pool_count ( SELECT pool, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY pool ),
     PROJECTION prj_tx_from_count ( SELECT tx_from, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY tx_from ),
+    PROJECTION prj_caller_count ( SELECT caller, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY caller ),
     PROJECTION prj_user_count ( SELECT user, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY user ),
     PROJECTION prj_input_contract_count ( SELECT input_contract, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY input_contract ),
     PROJECTION prj_output_contract_count ( SELECT output_contract, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY output_contract ),
@@ -111,6 +114,7 @@ CREATE TABLE IF NOT EXISTS swaps (
     PROJECTION prj_all_by_minute ( SELECT protocol, factory, pool, input_contract, output_contract, minute, count() GROUP BY protocol, factory, pool, input_contract, output_contract, minute ),
     PROJECTION prj_protocol_by_minute ( SELECT protocol, minute, count() GROUP BY protocol, minute ),
     PROJECTION prj_tx_from_by_minute ( SELECT tx_from, minute, count() GROUP BY tx_from, minute ),
+    PROJECTION prj_caller_by_minute ( SELECT caller, minute, count() GROUP BY caller, minute ),
     PROJECTION prj_factory_by_minute ( SELECT factory, minute, count() GROUP BY factory, minute ),
     PROJECTION prj_pool_by_minute ( SELECT pool, minute, count() GROUP BY pool, minute ),
     PROJECTION prj_user_by_minute ( SELECT user, minute, count() GROUP BY user, minute ),
@@ -123,7 +127,7 @@ ENGINE = MergeTree
 ORDER BY (
     minute, timestamp, block_num
 )
-COMMENT 'Transfers including ERC-20, WETH transfers';
+COMMENT 'DEX swap events normalized across supported protocols';
 
 
 -- SunPump TokenPurchased: User buys tokens with TRX (TRX → Token)
@@ -140,6 +144,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -178,6 +183,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -216,6 +222,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -255,6 +262,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -295,6 +303,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -349,6 +358,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -387,6 +397,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -429,6 +440,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -467,6 +479,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -505,6 +518,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -543,6 +557,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -581,6 +596,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -635,6 +651,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -673,6 +690,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -711,6 +729,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -752,6 +771,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(call_caller != '', call_caller, tx_from) AS caller,
 
     -- log --
     log_index,
@@ -790,6 +810,7 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
+    if(caller != '', caller, if(call_caller != '', call_caller, tx_from)) AS caller,
 
     -- log --
     log_index,


### PR DESCRIPTION
## Summary
Fixes #187

This PR adds `caller` as a first-class dimension on the DEX `swaps` dataset and adds minute-level projections for both `caller` and `tx_from`.

Users querying swaps can now distinguish the transaction sender from the effective call-level caller when extended call metadata is available. This makes caller-based analysis possible without giving up the existing `tx_from` dimension.

## Root cause
The normalized `swaps` table exposed `tx_from`, but it did not surface call metadata as a queryable field even though the underlying log templates already captured `call_caller`. As a result, downstream ClickHouse queries could not group or filter swaps by `caller`, and only `tx_from` had a minute-level projection.

## Fix
The swaps schema now includes a `caller` column with a non-empty constraint. Each swap materialized view populates it consistently by preferring `call_caller` and falling back to `tx_from` when call metadata is unavailable. The DCA.fun swap path preserves its explicit event-level `caller` first, then falls back to call metadata and finally `tx_from`.

The ClickHouse projections now include both `prj_caller_count` and `prj_caller_by_minute`, alongside the existing `tx_from` projection. The example queries now also cover grouped `minute + caller` and `minute + tx_from` access patterns.

## Validation
I ran `git diff --check` successfully and verified the affected SQL definitions and examples for the new column and projections.

Live ClickHouse execution validation is intentionally deferred until the remaining milestone PRs are merged, so the final combined schema can be tested together.
