### PR TITLE
[codex] restore aggregate uaw fields

### DIFF
--- a/evm-dex/clickhouse/schema.3.mv.state_ohlc_prices.sql
+++ b/evm-dex/clickhouse/schema.3.mv.state_ohlc_prices.sql
@@ -48,6 +48,9 @@ CREATE TABLE IF NOT EXISTS state_ohlc_prices (
 
     -- universal --
     transactions            SimpleAggregateFunction(sum, UInt64) COMMENT 'number of transactions in the window',
+    uniq_tx_from            AggregateFunction(uniq, String) COMMENT 'unique transaction from addresses in the window',
+    uniq_user               AggregateFunction(uniq, String) COMMENT 'unique user addresses in the window',
+    uniq_caller             AggregateFunction(uniq, String) COMMENT 'unique caller addresses in the window',
 
     -- indexes --
     INDEX idx_timestamp         (timestamp)         TYPE minmax                 GRANULARITY 1,
@@ -122,7 +125,10 @@ SELECT
     sum(nf1)                AS net_flow1,
 
     /* universal */
-    count()                 AS transactions
+    count()                 AS transactions,
+    uniqState(tx_from)      AS uniq_tx_from,
+    uniqState(user)         AS uniq_user,
+    uniqState(caller)       AS uniq_caller
 FROM swaps s
 GROUP BY
     -- bar interval

--- a/evm-dex/clickhouse/schema.3.mv.state_pools_aggregating_by_pool.sql
+++ b/evm-dex/clickhouse/schema.3.mv.state_pools_aggregating_by_pool.sql
@@ -29,6 +29,9 @@ CREATE TABLE IF NOT EXISTS state_pools_aggregating_by_pool (
 
     -- universal --
     transactions            SimpleAggregateFunction(sum, UInt64) COMMENT 'total number of transactions',
+    uniq_tx_from            AggregateFunction(uniq, String) COMMENT 'unique transaction from addresses',
+    uniq_user               AggregateFunction(uniq, String) COMMENT 'unique user addresses',
+    uniq_caller             AggregateFunction(uniq, String) COMMENT 'unique caller addresses',
 
     -- indexes --
     INDEX idx_min_timestamp     (min_timestamp)              TYPE minmax             GRANULARITY 1,
@@ -55,7 +58,10 @@ CREATE TABLE IF NOT EXISTS state_pools_aggregating_by_pool (
             protocol,
 
             -- universal --
-            sum(transactions)
+            sum(transactions),
+            uniqMerge(uniq_tx_from),
+            uniqMerge(uniq_user),
+            uniqMerge(uniq_caller)
         GROUP BY pool, factory, protocol
     )
 )
@@ -78,6 +84,9 @@ SELECT
     protocol, factory, pool,
 
     -- universal --
-    count() as transactions
+    count() as transactions,
+    uniqState(tx_from) AS uniq_tx_from,
+    uniqState(user) AS uniq_user,
+    uniqState(caller) AS uniq_caller
 FROM swaps
 GROUP BY protocol, factory, pool;

--- a/evm-dex/clickhouse/schema.4.view.ohlc_prices.sql
+++ b/evm-dex/clickhouse/schema.4.view.ohlc_prices.sql
@@ -36,3 +36,32 @@ GROUP BY
     interval_min,
     pool, factory, protocol, token0, token1,
     timestamp;
+
+CREATE VIEW IF NOT EXISTS ohlc_prices_uaw AS
+SELECT
+    -- bar interval --
+    timestamp,
+    interval_min,
+
+    -- timestamp & block number --
+    min(min_timestamp) as min_timestamp,
+    max(max_timestamp) as max_timestamp,
+    min(min_block_num) as min_block_num,
+    max(max_block_num) as max_block_num,
+
+    -- DEX identity --
+    pool,
+    factory,
+    protocol,
+    token0,
+    token1,
+
+    -- universal UAW-style fields --
+    uniqMerge(uniq_tx_from) AS uaw_tx_from,
+    uniqMerge(uniq_user) AS uaw_user,
+    uniqMerge(uniq_caller) AS uaw_caller
+FROM state_ohlc_prices
+GROUP BY
+    interval_min,
+    pool, factory, protocol, token0, token1,
+    timestamp;


### PR DESCRIPTION
## Summary
Fixes #188

This PR restores and expands the DEX aggregate uniqueness fields by adding aggregate states and merge outputs for:

- `tx_from`
- `user`
- `caller`

It also adds a new `ohlc_prices_uaw` view to expose UAW-style uniqueness metrics for OHLC buckets.

## Root cause
The aggregate schemas no longer exposed the uniqueness fields needed for downstream consumers that rely on address-level aggregate metrics in pool summaries and OHLC outputs.

## Fix
`state_pools_aggregating_by_pool` now stores and merges unique aggregate states for `tx_from`, `user`, and `caller`.

`state_ohlc_prices` now stores unique aggregate states for the same three dimensions per interval bucket.

A new `ohlc_prices_uaw` view in `evm-dex/clickhouse/schema.4.view.ohlc_prices.sql` exposes the merged counts as:

- `uaw_tx_from`
- `uaw_user`
- `uaw_caller`

This view may be expensive on large datasets, but it gives a straightforward query surface that can later be optimized with refreshable/materialized views if needed.

## Validation
I ran `git diff --check` successfully and verified the updated aggregate definitions and new view SQL.
