### PR TITLE
[codex] add unified uaw projections

### DIFF
--- a/evm-dex/clickhouse/schema.3.mv.state_pools_uaw.sql
+++ b/evm-dex/clickhouse/schema.3.mv.state_pools_uaw.sql
@@ -1,6 +1,97 @@
 -- Unique Active Wallets (UAW) tables --
--- These tables use AggregatingMergeTree for efficient unique user counting
--- Instead of expensive uniqMerge operations, use: SELECT count() FROM state_pools_uaw_by_user WHERE pool = '<pool>'
+-- These tables use AggregatingMergeTree for efficient distinct-address counting
+
+CREATE TABLE IF NOT EXISTS state_pools_uaw (
+    -- DEX identity
+    protocol                    Enum8(
+        'sunpump' = 1,
+        'uniswap_v1' = 2,
+        'uniswap_v2' = 3,
+        'uniswap_v3' = 4,
+        'uniswap_v4' = 5,
+        'curvefi' = 6,
+        'balancer' = 7,
+        'bancor' = 8,
+        'cow' = 9,
+        'aerodrome' = 10,
+        'dodo' = 11,
+        'woofi' = 12,
+        'traderjoe' = 13,
+        'kyber_elastic' = 14,
+        'dca_dot_fun' = 15
+    ) COMMENT 'protocol identifier',
+    factory              LowCardinality(String),
+    pool                 String,
+    dimension            Enum8(
+        'user' = 1,
+        'tx_from' = 2,
+        'caller' = 3
+    ) COMMENT 'address dimension type',
+    address              String COMMENT 'normalized address for the selected dimension',
+
+    -- timestamp & block number --
+    min_timestamp         SimpleAggregateFunction(min, DateTime('UTC', 0)) COMMENT 'first timestamp seen',
+    max_timestamp         SimpleAggregateFunction(max, DateTime('UTC', 0)) COMMENT 'last timestamp seen',
+    min_block_num         SimpleAggregateFunction(min, UInt32) COMMENT 'first block number seen',
+    max_block_num         SimpleAggregateFunction(max, UInt32) COMMENT 'last block number seen',
+
+    -- projections --
+    PROJECTION prj_factory_address (
+        SELECT
+            dimension,
+            factory,
+            address,
+            min(min_timestamp),
+            max(max_timestamp),
+            min(min_block_num),
+            max(max_block_num)
+        GROUP BY dimension, factory, address
+    ),
+    PROJECTION prj_pool_factory_address (
+        SELECT
+            dimension,
+            pool,
+            factory,
+            address,
+            min(min_timestamp),
+            max(max_timestamp),
+            min(min_block_num),
+            max(max_block_num)
+        GROUP BY dimension, pool, factory, address
+    )
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (dimension, pool, factory, protocol, address)
+COMMENT 'Normalized unique addresses per pool for caller, user, and tx_from analytics';
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_state_pools_uaw
+TO state_pools_uaw
+AS
+SELECT
+    protocol,
+    factory,
+    pool,
+    dimension,
+    address,
+    min(timestamp) AS min_timestamp,
+    max(timestamp) AS max_timestamp,
+    min(block_num) AS min_block_num,
+    max(block_num) AS max_block_num
+FROM (
+    SELECT protocol, factory, pool, 'user' AS dimension, user AS address, timestamp, block_num
+    FROM swaps
+
+    UNION ALL
+
+    SELECT protocol, factory, pool, 'tx_from' AS dimension, tx_from AS address, timestamp, block_num
+    FROM swaps
+
+    UNION ALL
+
+    SELECT protocol, factory, pool, 'caller' AS dimension, caller AS address, timestamp, block_num
+    FROM swaps
+)
+GROUP BY protocol, factory, pool, dimension, address;
 
 -- UAW by user address --
 CREATE TABLE IF NOT EXISTS state_pools_uaw_by_user (
@@ -32,11 +123,28 @@ CREATE TABLE IF NOT EXISTS state_pools_uaw_by_user (
     min_block_num         SimpleAggregateFunction(min, UInt32) COMMENT 'first block number seen',
     max_block_num         SimpleAggregateFunction(max, UInt32) COMMENT 'last block number seen',
 
-    -- indexes --
-    INDEX idx_protocol          (protocol)                   TYPE set(8)             GRANULARITY 1,
-    INDEX idx_factory           (factory)                    TYPE set(1024)          GRANULARITY 1,
-    INDEX idx_min_timestamp     (min_timestamp)              TYPE minmax             GRANULARITY 1,
-    INDEX idx_max_timestamp     (max_timestamp)              TYPE minmax             GRANULARITY 1
+    -- projections --
+    PROJECTION prj_factory_user (
+        SELECT
+            factory,
+            user,
+            min(min_timestamp),
+            max(max_timestamp),
+            min(min_block_num),
+            max(max_block_num)
+        GROUP BY factory, user
+    ),
+    PROJECTION prj_pool_factory_user (
+        SELECT
+            pool,
+            factory,
+            user,
+            min(min_timestamp),
+            max(max_timestamp),
+            min(min_block_num),
+            max(max_block_num)
+        GROUP BY pool, factory, user
+    )
 )
 ENGINE = AggregatingMergeTree
 ORDER BY (pool, factory, protocol, user)
@@ -87,11 +195,28 @@ CREATE TABLE IF NOT EXISTS state_pools_uaw_by_tx_from (
     min_block_num         SimpleAggregateFunction(min, UInt32) COMMENT 'first block number seen',
     max_block_num         SimpleAggregateFunction(max, UInt32) COMMENT 'last block number seen',
 
-    -- indexes --
-    INDEX idx_protocol          (protocol)                   TYPE set(8)             GRANULARITY 1,
-    INDEX idx_factory           (factory)                    TYPE set(1024)          GRANULARITY 1,
-    INDEX idx_min_timestamp     (min_timestamp)              TYPE minmax             GRANULARITY 1,
-    INDEX idx_max_timestamp     (max_timestamp)              TYPE minmax             GRANULARITY 1
+    -- projections --
+    PROJECTION prj_factory_tx_from (
+        SELECT
+            factory,
+            tx_from,
+            min(min_timestamp),
+            max(max_timestamp),
+            min(min_block_num),
+            max(max_block_num)
+        GROUP BY factory, tx_from
+    ),
+    PROJECTION prj_pool_factory_tx_from (
+        SELECT
+            pool,
+            factory,
+            tx_from,
+            min(min_timestamp),
+            max(max_timestamp),
+            min(min_block_num),
+            max(max_block_num)
+        GROUP BY pool, factory, tx_from
+    )
 )
 ENGINE = AggregatingMergeTree
 ORDER BY (pool, factory, protocol, tx_from)
@@ -111,3 +236,72 @@ SELECT
     max(block_num) AS max_block_num
 FROM swaps
 GROUP BY protocol, factory, pool, tx_from;
+
+-- UAW by caller address --
+CREATE TABLE IF NOT EXISTS state_pools_uaw_by_caller (
+    -- DEX identity
+    protocol                    Enum8(
+        'sunpump' = 1,
+        'uniswap_v1' = 2,
+        'uniswap_v2' = 3,
+        'uniswap_v3' = 4,
+        'uniswap_v4' = 5,
+        'curvefi' = 6,
+        'balancer' = 7,
+        'bancor' = 8,
+        'cow' = 9,
+        'aerodrome' = 10,
+        'dodo' = 11,
+        'woofi' = 12,
+        'traderjoe' = 13,
+        'kyber_elastic' = 14,
+        'dca_dot_fun' = 15
+    ) COMMENT 'protocol identifier',
+    factory              LowCardinality(String),
+    pool                 String,
+    caller               String COMMENT 'unique caller address',
+
+    -- timestamp & block number --
+    min_timestamp         SimpleAggregateFunction(min, DateTime('UTC', 0)) COMMENT 'first timestamp seen',
+    max_timestamp         SimpleAggregateFunction(max, DateTime('UTC', 0)) COMMENT 'last timestamp seen',
+    min_block_num         SimpleAggregateFunction(min, UInt32) COMMENT 'first block number seen',
+    max_block_num         SimpleAggregateFunction(max, UInt32) COMMENT 'last block number seen',
+
+    -- projections --
+    PROJECTION prj_factory_caller (
+        SELECT
+            factory,
+            caller,
+            min(min_timestamp),
+            max(max_timestamp),
+            min(min_block_num),
+            max(max_block_num)
+        GROUP BY factory, caller
+    ),
+    PROJECTION prj_pool_factory_caller (
+        SELECT
+            pool,
+            factory,
+            caller,
+            min(min_timestamp),
+            max(max_timestamp),
+            min(min_block_num),
+            max(max_block_num)
+        GROUP BY pool, factory, caller
+    )
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (pool, factory, protocol, caller)
+COMMENT 'Unique caller addresses per pool for UAW calculation';
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_state_pools_uaw_by_caller
+TO state_pools_uaw_by_caller
+AS
+SELECT
+    protocol, factory, pool, caller,
+    min(timestamp) AS min_timestamp,
+    max(timestamp) AS max_timestamp,
+    min(block_num) AS min_block_num,
+    max(block_num) AS max_block_num
+FROM swaps
+GROUP BY protocol, factory, pool, caller;


### PR DESCRIPTION
## Summary
Fixes #189

This PR replaces the index-only UAW layout with projection-oriented grouped distinct layouts and expands UAW coverage to include `caller`.

It also introduces a normalized `state_pools_uaw` table that stores all three address dimensions (`user`, `tx_from`, `caller`) behind a common `dimension` + `address` shape.

## Root cause
The prior schema only exposed `state_pools_uaw_by_user` and `state_pools_uaw_by_tx_from`, and relied on secondary indexes rather than projections tailored to grouped distinct query patterns. That left factory-level and factory+pool-level distinct address analytics less explicit and less aligned with ClickHouse projection optimizations.

## Fix
This PR adds:

- a normalized `state_pools_uaw` table
- grouped projections for `dimension + factory + address`
- grouped projections for `dimension + pool + factory + address`
- a new `state_pools_uaw_by_caller` table for compatibility with the per-dimension layout
- grouped projections on all three per-dimension tables:
  - `state_pools_uaw_by_user`
  - `state_pools_uaw_by_tx_from`
  - `state_pools_uaw_by_caller`

This keeps the specialized tables easy to query while also providing a single unified table for address-dimension analytics across `caller`, `user`, and `tx_from`.

## Validation
I ran `git diff --check` successfully and verified the new projections and materialized views in the ClickHouse schema.
