### PR TITLE
[codex] add template log ttl

### DIFF
--- a/evm-dex/clickhouse/schema.0.templates.sql
+++ b/evm-dex/clickhouse/schema.0.templates.sql
@@ -18,6 +18,10 @@ CREATE TABLE IF NOT EXISTS TEMPLATE_TRANSACTION (
     tx_value                    UInt256
 )
 ENGINE = MergeTree
+-- TTL is applied to all base data tables
+-- to automatically clean up old data
+-- production tables are derived from MV's on these base tables
+TTL timestamp + INTERVAL 1 DAY
 ORDER BY (
     minute, timestamp, block_num
 );


### PR DESCRIPTION
## Summary
Fixes #194

This PR adds a 1-day TTL to the DEX base template tables so log-derived datasets built from `TEMPLATE_LOG` inherit the intended short-lived retention behavior.

## Root cause
`TEMPLATE_LOG` was defined from `TEMPLATE_TRANSACTION`, but the DEX template did not include the base TTL already used in sibling ClickHouse packages. That meant the log-backed raw/base tables did not automatically expire old data.

## Fix
This PR adds:

- `TTL timestamp + INTERVAL 1 DAY`

on `TEMPLATE_TRANSACTION` in `evm-dex/clickhouse/schema.0.templates.sql`, which is inherited by `TEMPLATE_LOG` tables created from that base template.

## Validation
I ran `git diff --check` successfully and verified the updated template definition.
