### PR TITLE
[codex] adjust swaps minute projections

### DIFF
--- a/evm-dex/clickhouse/schema.2.mv.swaps.sql
+++ b/evm-dex/clickhouse/schema.2.mv.swaps.sql
@@ -108,9 +108,9 @@ CREATE TABLE IF NOT EXISTS swaps (
 
     -- minute --
     PROJECTION prj_log_address_by_minute ( SELECT log_address, minute GROUP BY log_address, minute ),
+    PROJECTION prj_log_topic0_by_minute ( SELECT log_topic0, minute GROUP BY log_topic0, minute ),
 
     -- minute --
-    PROJECTION prj_all_by_minute ( SELECT protocol, factory, pool, input_contract, output_contract, minute, count() GROUP BY protocol, factory, pool, input_contract, output_contract, minute ),
     PROJECTION prj_protocol_by_minute ( SELECT protocol, minute, count() GROUP BY protocol, minute ),
     PROJECTION prj_tx_from_by_minute ( SELECT tx_from, minute, count() GROUP BY tx_from, minute ),
     PROJECTION prj_caller_by_minute ( SELECT caller, minute, count() GROUP BY caller, minute ),


### PR DESCRIPTION
## Summary
Fixes #197
Fixes #196

This PR adjusts the DEX `swaps` minute-level projection layout by:

- adding a minute projection on `log_topic0`
- removing `prj_all_by_minute`

## Root cause
The `swaps` table was missing a minute-level projection for `log_topic0`, while also carrying a broad `prj_all_by_minute` projection that could overlap with more targeted minute projections.

## Fix
This PR adds:

- `PROJECTION prj_log_topic0_by_minute ( SELECT log_topic0, minute GROUP BY log_topic0, minute )`

and removes:

- `prj_all_by_minute`

This keeps the minute projection set more focused and aligned with the intended query patterns.

## Validation
I ran `git diff --check` successfully and verified the updated swaps projection block.
