### PR TITLE
[codex] align swaps call metadata

### DIFF
--- a/evm-dex/clickhouse/examples/Swaps.sql
+++ b/evm-dex/clickhouse/examples/Swaps.sql
@@ -100,14 +100,14 @@ WHERE
 ORDER BY minute DESC, timestamp DESC, block_num DESC
 LIMIT 10;
 
--- grouped swaps by minute and caller --
+-- grouped swaps by minute and call_caller --
 SELECT
     minute,
-    caller,
+    call_caller,
     count() AS swaps_count
 FROM swaps
-WHERE caller = '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45'
-GROUP BY minute, caller
+WHERE call_caller = '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45'
+GROUP BY minute, call_caller
 ORDER BY minute DESC
 LIMIT 10;
 

--- a/evm-dex/clickhouse/examples/UAW-benchmarks.sql
+++ b/evm-dex/clickhouse/examples/UAW-benchmarks.sql
@@ -47,24 +47,24 @@ GROUP BY pool, factory
 ORDER BY uaw_user DESC
 LIMIT 50;
 
--- unique caller by protocol + factory
+-- unique call_caller by protocol + factory
 EXPLAIN indexes = 1, projections = 1
 SELECT
     protocol,
     factory,
-    uniqExact(caller) AS uaw_caller
+    uniqExact(call_caller) AS uaw_call_caller
 FROM swaps
 GROUP BY protocol, factory
-ORDER BY uaw_caller DESC
+ORDER BY uaw_call_caller DESC
 LIMIT 50;
 
 SELECT
     protocol,
     factory,
-    uniqExact(caller) AS uaw_caller
+    uniqExact(call_caller) AS uaw_call_caller
 FROM swaps
 GROUP BY protocol, factory
-ORDER BY uaw_caller DESC
+ORDER BY uaw_call_caller DESC
 LIMIT 50;
 
 -- -----------------------------------------------------------------------------
@@ -127,24 +127,24 @@ GROUP BY factory
 ORDER BY uaw_user DESC
 LIMIT 50;
 
--- caller distinct counts by pool + factory
+-- call_caller distinct counts by pool + factory
 EXPLAIN indexes = 1, projections = 1
 SELECT
     pool,
     factory,
-    count() AS uaw_caller
-FROM state_pools_uaw_by_caller
+    count() AS uaw_call_caller
+FROM state_pools_uaw_by_call_caller
 GROUP BY pool, factory
-ORDER BY uaw_caller DESC
+ORDER BY uaw_call_caller DESC
 LIMIT 50;
 
 SELECT
     pool,
     factory,
-    count() AS uaw_caller
-FROM state_pools_uaw_by_caller
+    count() AS uaw_call_caller
+FROM state_pools_uaw_by_call_caller
 GROUP BY pool, factory
-ORDER BY uaw_caller DESC
+ORDER BY uaw_call_caller DESC
 LIMIT 50;
 
 -- -----------------------------------------------------------------------------
@@ -193,14 +193,14 @@ GROUP BY dimension, pool, factory
 ORDER BY dimension, unique_addresses DESC
 LIMIT 100;
 
--- focused benchmark for caller only
+-- focused benchmark for call_caller only
 EXPLAIN indexes = 1, projections = 1
 SELECT
     dimension,
     factory,
     count() AS unique_addresses
 FROM state_pools_uaw
-WHERE dimension = 'caller'
+WHERE dimension = 'call_caller'
 GROUP BY dimension, factory
 ORDER BY unique_addresses DESC
 LIMIT 50;
@@ -210,7 +210,7 @@ SELECT
     factory,
     count() AS unique_addresses
 FROM state_pools_uaw
-WHERE dimension = 'caller'
+WHERE dimension = 'call_caller'
 GROUP BY dimension, factory
 ORDER BY unique_addresses DESC
 LIMIT 50;

--- a/evm-dex/clickhouse/schema.2.mv.swaps.sql
+++ b/evm-dex/clickhouse/schema.2.mv.swaps.sql
@@ -10,7 +10,10 @@ CREATE TABLE IF NOT EXISTS swaps (
     tx_index                    UInt32, -- derived from Substreams
     tx_hash                     String,
     tx_from                     String,
-    caller                      String COMMENT 'Call-level caller address, falling back to tx_from when unavailable',
+    call_caller                 String COMMENT 'Call-level caller address from shared log metadata',
+    call_index                  UInt32 COMMENT 'Call index from shared log metadata',
+    call_depth                  UInt32 COMMENT 'Call depth from shared log metadata',
+    call_type                   LowCardinality(String) COMMENT 'Call type from shared log metadata',
 
     -- log --
     log_index                   UInt32, -- derived from Substreams
@@ -48,7 +51,6 @@ CREATE TABLE IF NOT EXISTS swaps (
     CONSTRAINT log_topic0_not_empty CHECK log_topic0 != '',
     CONSTRAINT tx_hash_not_empty CHECK tx_hash != '',
     CONSTRAINT tx_from_not_empty CHECK tx_from != '',
-    CONSTRAINT caller_not_empty CHECK caller != '',
     CONSTRAINT factory_not_empty CHECK factory != '',
     CONSTRAINT pool_not_empty CHECK pool != '',
     CONSTRAINT user_not_empty CHECK user != '',
@@ -78,7 +80,7 @@ CREATE TABLE IF NOT EXISTS swaps (
     PROJECTION prj_factory_count ( SELECT factory, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY factory ),
     PROJECTION prj_pool_count ( SELECT pool, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY pool ),
     PROJECTION prj_tx_from_count ( SELECT tx_from, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY tx_from ),
-    PROJECTION prj_caller_count ( SELECT caller, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY caller ),
+    PROJECTION prj_call_caller_count ( SELECT call_caller, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY call_caller ),
     PROJECTION prj_user_count ( SELECT user, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY user ),
     PROJECTION prj_input_contract_count ( SELECT input_contract, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY input_contract ),
     PROJECTION prj_output_contract_count ( SELECT output_contract, count(), min(block_num), max(block_num), min(timestamp), max(timestamp), min(minute), max(minute) GROUP BY output_contract ),
@@ -113,7 +115,7 @@ CREATE TABLE IF NOT EXISTS swaps (
     -- minute --
     PROJECTION prj_protocol_by_minute ( SELECT protocol, minute, count() GROUP BY protocol, minute ),
     PROJECTION prj_tx_from_by_minute ( SELECT tx_from, minute, count() GROUP BY tx_from, minute ),
-    PROJECTION prj_caller_by_minute ( SELECT caller, minute, count() GROUP BY caller, minute ),
+    PROJECTION prj_call_caller_by_minute ( SELECT call_caller, minute, count() GROUP BY call_caller, minute ),
     PROJECTION prj_factory_by_minute ( SELECT factory, minute, count() GROUP BY factory, minute ),
     PROJECTION prj_pool_by_minute ( SELECT pool, minute, count() GROUP BY pool, minute ),
     PROJECTION prj_user_by_minute ( SELECT user, minute, count() GROUP BY user, minute ),
@@ -143,7 +145,10 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -182,7 +187,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -221,7 +232,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -261,7 +278,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -302,7 +325,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -357,7 +386,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -396,7 +431,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -439,7 +480,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -478,7 +525,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -517,7 +570,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -556,7 +615,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -595,7 +660,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -650,7 +721,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -689,7 +766,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -728,7 +811,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,
@@ -770,7 +859,13 @@ SELECT
     tx_index,
     tx_hash,
     tx_from,
-    if(call_caller != '', call_caller, tx_from) AS caller,
+    call_caller,
+    call_index,
+    call_depth,
+    call_type,
+    call_index,
+    call_depth,
+    call_type,
 
     -- log --
     log_index,

--- a/evm-dex/clickhouse/schema.3.mv.state_ohlc_prices.sql
+++ b/evm-dex/clickhouse/schema.3.mv.state_ohlc_prices.sql
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS state_ohlc_prices (
     transactions            SimpleAggregateFunction(sum, UInt64) COMMENT 'number of transactions in the window',
     uniq_tx_from            AggregateFunction(uniq, String) COMMENT 'unique transaction from addresses in the window',
     uniq_user               AggregateFunction(uniq, String) COMMENT 'unique user addresses in the window',
-    uniq_caller             AggregateFunction(uniq, String) COMMENT 'unique caller addresses in the window',
+    uniq_caller             AggregateFunction(uniq, String) COMMENT 'unique call_caller addresses in the window',
 
     -- indexes --
     INDEX idx_timestamp         (timestamp)         TYPE minmax                 GRANULARITY 1,
@@ -127,7 +127,7 @@ SELECT
     count()                 AS transactions,
     uniqState(tx_from)      AS uniq_tx_from,
     uniqState(user)         AS uniq_user,
-    uniqState(caller)       AS uniq_caller
+    uniqState(call_caller)       AS uniq_caller
 FROM swaps s
 GROUP BY
     -- bar interval

--- a/evm-dex/clickhouse/schema.3.mv.state_pools_aggregating_by_pool.sql
+++ b/evm-dex/clickhouse/schema.3.mv.state_pools_aggregating_by_pool.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS state_pools_aggregating_by_pool (
     transactions            SimpleAggregateFunction(sum, UInt64) COMMENT 'total number of transactions',
     uniq_tx_from            AggregateFunction(uniq, String) COMMENT 'unique transaction from addresses',
     uniq_user               AggregateFunction(uniq, String) COMMENT 'unique user addresses',
-    uniq_caller             AggregateFunction(uniq, String) COMMENT 'unique caller addresses',
+    uniq_caller             AggregateFunction(uniq, String) COMMENT 'unique call_caller addresses',
 
     -- indexes --
     INDEX idx_min_timestamp     (min_timestamp)              TYPE minmax             GRANULARITY 1,
@@ -86,6 +86,6 @@ SELECT
     count() as transactions,
     uniqState(tx_from) AS uniq_tx_from,
     uniqState(user) AS uniq_user,
-    uniqState(caller) AS uniq_caller
+    uniqState(call_caller) AS uniq_caller
 FROM swaps
 GROUP BY protocol, factory, pool;

--- a/evm-dex/clickhouse/schema.3.mv.state_pools_uaw.sql
+++ b/evm-dex/clickhouse/schema.3.mv.state_pools_uaw.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS state_pools_uaw (
     dimension            Enum8(
         'user' = 1,
         'tx_from' = 2,
-        'caller' = 3
+        'call_caller' = 3
     ) COMMENT 'address dimension type',
     address              String COMMENT 'normalized address for the selected dimension',
 
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS state_pools_uaw (
 )
 ENGINE = AggregatingMergeTree
 ORDER BY (dimension, pool, factory, protocol, address)
-COMMENT 'Normalized unique addresses per pool for caller, user, and tx_from analytics';
+COMMENT 'Normalized unique addresses per pool for call_caller, user, and tx_from analytics';
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_state_pools_uaw
 TO state_pools_uaw
@@ -87,7 +87,7 @@ FROM (
 
     UNION ALL
 
-    SELECT protocol, factory, pool, 'caller' AS dimension, caller AS address, timestamp, block_num
+    SELECT protocol, factory, pool, 'call_caller' AS dimension, call_caller AS address, timestamp, block_num
     FROM swaps
 )
 GROUP BY protocol, factory, pool, dimension, address;
@@ -234,8 +234,8 @@ SELECT
 FROM swaps
 GROUP BY protocol, factory, pool, tx_from;
 
--- UAW by caller address --
-CREATE TABLE IF NOT EXISTS state_pools_uaw_by_caller (
+-- UAW by call_caller address --
+CREATE TABLE IF NOT EXISTS state_pools_uaw_by_call_caller (
     -- DEX identity
     protocol                    Enum8(
         'sunpump' = 1,
@@ -255,7 +255,7 @@ CREATE TABLE IF NOT EXISTS state_pools_uaw_by_caller (
     ) COMMENT 'protocol identifier',
     factory              LowCardinality(String),
     pool                 String,
-    caller               String COMMENT 'unique caller address',
+    call_caller               String COMMENT 'unique call_caller address',
 
     -- timestamp & block number --
     min_timestamp         SimpleAggregateFunction(min, DateTime('UTC', 0)) COMMENT 'first timestamp seen',
@@ -264,40 +264,40 @@ CREATE TABLE IF NOT EXISTS state_pools_uaw_by_caller (
     max_block_num         SimpleAggregateFunction(max, UInt32) COMMENT 'last block number seen',
 
     -- projections --
-    PROJECTION prj_factory_caller (
+    PROJECTION prj_factory_call_caller (
         SELECT
             factory,
-            caller,
+            call_caller,
             min(min_timestamp),
             max(max_timestamp),
             min(min_block_num),
             max(max_block_num)
-        GROUP BY factory, caller
+        GROUP BY factory, call_caller
     ),
-    PROJECTION prj_pool_factory_caller (
+    PROJECTION prj_pool_factory_call_caller (
         SELECT
             pool,
             factory,
-            caller,
+            call_caller,
             min(min_timestamp),
             max(max_timestamp),
             min(min_block_num),
             max(max_block_num)
-        GROUP BY pool, factory, caller
+        GROUP BY pool, factory, call_caller
     )
 )
 ENGINE = AggregatingMergeTree
-ORDER BY (pool, factory, protocol, caller)
-COMMENT 'Unique caller addresses per pool for UAW calculation';
+ORDER BY (pool, factory, protocol, call_caller)
+COMMENT 'Unique call_caller addresses per pool for UAW calculation';
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS mv_state_pools_uaw_by_caller
-TO state_pools_uaw_by_caller
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_state_pools_uaw_by_call_caller
+TO state_pools_uaw_by_call_caller
 AS
 SELECT
-    protocol, factory, pool, caller,
+    protocol, factory, pool, call_caller,
     min(timestamp) AS min_timestamp,
     max(timestamp) AS max_timestamp,
     min(block_num) AS min_block_num,
     max(block_num) AS max_block_num
 FROM swaps
-GROUP BY protocol, factory, pool, caller;
+GROUP BY protocol, factory, pool, call_caller;


### PR DESCRIPTION
## Summary
Fixes #195

This PR aligns the DEX `swaps` dataset with the shared `TEMPLATE_LOG` call metadata naming by replacing `caller` with `call_caller` and adding the remaining `call_*` fields.

## Root cause
The shared log template already used `call_*` field names, but the `swaps` table exposed a partial and differently named call metadata surface. That created inconsistency between the template-level schema and the normalized swaps dataset.

## Fix
This PR updates `evm-dex/clickhouse/schema.2.mv.swaps.sql` to:

- rename `caller` to `call_caller`
- add `call_index`
- add `call_depth`
- add `call_type`

All swap materialized views now propagate:

- `call_caller`
- `call_index`
- `call_depth`
- `call_type`

## Reasoning for no fallback
`call_caller` no longer falls back to `tx_from` when call metadata is unavailable.

This is intentional because `tx_from` and `call_caller` are different concepts:

- `tx_from` is the transaction sender/signing address
- `call_caller` is the call-level caller from extended call metadata

Using `tx_from` as a storage-level fallback would blur those semantics and make it impossible for downstream consumers to distinguish:

- a real `call_caller`
- missing `call_*` metadata
- a synthetic fallback value

This matters especially on chains such as Avalanche where `call_*` metadata may not be available at all. In those cases, leaving `call_caller` blank is more accurate than populating it with `tx_from`, because it preserves the fact that the chain did not provide call-level metadata.

That allows the UI and downstream analytics to make an explicit choice:

- use strict `call_caller` only when present
- use `tx_from` separately
- or derive an application-level fallback later if needed

## Validation
I ran `git diff --check` successfully and verified the updated swaps schema and MV projections.
