### PR TITLE
Fix Uniswap V3 swap direction in materialized view

### DIFF
--- a/evm-dex/clickhouse/schema.2.mv.swaps.sql
+++ b/evm-dex/clickhouse/schema.2.mv.swaps.sql
@@ -652,7 +652,7 @@ SELECT
     if (toInt256(amount0) > toInt256(0), token0, token1)      AS input_contract,
     if (toInt256(amount0) > toInt256(0), abs(toInt256(amount0)), abs(toInt256(amount1))) AS input_amount,
 
-    -- Output side: negative amount0 means token0 left the pool (trader receives token0)
+    -- Output side: the token with a negative amount left the pool (trader receives it); amount0>0 → token1 out, amount0<0 → token0 out
     if (toInt256(amount0) > toInt256(0), token1, token0)      AS output_contract,
     if (toInt256(amount0) > toInt256(0), abs(toInt256(amount1)), abs(toInt256(amount0))) AS output_amount
 


### PR DESCRIPTION
V3 Swap event amounts use pool perspective: positive amount0 means token0 entered the pool (trader input), negative means it left (trader output). The condition was inverted, producing reversed input/output for all V3 swaps.

V4 uses caller/BalanceDelta perspective (opposite sign convention) so the same `amount0 < 0` condition is correct there — no change needed.

References:
- https://github.com/Uniswap/v3-sdk/blob/4e16fe8e56c8c26541545f138c89133794c7ce72/src/entities/pool.ts#L208
- https://docs.uniswap.org/contracts/v3/reference/core/interfaces/pool/IUniswapV3PoolEvents#swap